### PR TITLE
Make table header sticky

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -128,6 +128,18 @@ table tr td.cell_dual a.btn.btn-light.shot_clic {
   width: 50%;
 }
 
+.thead-relative {
+  position: relative;
+}
+
+.th-sticky {
+  position: sticky;
+}
+
+.th-sticky-by-minus-1-px {
+  top: -1px;
+}
+
 /* Small devices (landscape phones, 576px and up) */
 @media screen and (min-width: 576px) {
   .head__name {

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -102,15 +102,15 @@
   <h5><strong>Listado de pacientes que necesitan plasma</strong></h5>
   <div class="pt-3 pb-3">
     <table class='table table-hover table-responsive-sm'>
-      <thead class='thead-dark'>
+      <thead class='thead-dark thead-relative'>
         <tr>
-          <th scope='col'></th>
-          <th scope='col'>Tipo</th>
-          <th scope='col'>Hospital</th>
-          <th scope='col'>Contacto</th>
-          <th scope='col'>Nombre</th>
-          <th scope='col'>Apellido</th>
-          <th scope='col'>Info</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'></th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Tipo</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Hospital</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Contacto</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Nombre</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Apellido</th>
+          <th class="th-sticky th-sticky-by-minus-1-px" scope='col'>Info</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
A sticky header will make it easy to read stuff on the table that is already long enough

## Proof
![Sticky header for BloodSV Repo](https://user-images.githubusercontent.com/3196685/85936166-cbb8e800-b8ac-11ea-87a3-804b3ba13dc5.gif)
