### PR TITLE
Publicacion Automatica de cantidad de donantes a redes sociales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.1)
       devise (>= 4.7.1)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     ffi (1.13.1)
     globalid (0.4.2)
@@ -246,6 +250,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise
   devise-i18n
+  dotenv-rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/services/facebook_posting_service.rb
+++ b/app/services/facebook_posting_service.rb
@@ -1,0 +1,11 @@
+require 'net/http'
+class FacebookPostingService
+  def self.post_to_page(params = {})
+    uri = URI('https://graph.facebook.com/106960084420711/feed')
+    if(params[:message].nil? or params[:message].empty?)
+      raise ArgumentError, "Message should be present"
+    end
+    params[:access_token] = ENV['FACEBOOK_PAGE_ACCESS_TOKEN']
+    Net::HTTP.post_form(uri, params)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require 'rails/all'
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-
+Dotenv::Railtie.load
 module Bloodsv
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :contacts
   get :new_donor, to: 'contacts#new_donor'
+  get :donantes, to: 'contacts#index', defaults: { donors: 1 }
 
   root 'contacts#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :contacts
   get :new_donor, to: 'contacts#new_donor'
   get :donantes, to: 'contacts#index', defaults: { donors: 1 }
+  get :pacientes, to: 'contacts#index'
 
   root 'contacts#index'
 end

--- a/lib/tasks/social_media.rake
+++ b/lib/tasks/social_media.rake
@@ -2,17 +2,22 @@ namespace :social_media do
   desc "TODO"
   task daily_blood_donnors_report: :environment do
     link = "https://salvemosotrosv.com/donantes"
-    Contact.group(:blood_type)\
-      .select("blood_type, count(*) as total")\
-      .having("count(*) > 0")\
-      .map {|c| [c.blood_type, c.total] }.to_h\
+    Contact.group(:blood_type)
+      .select("blood_type, count(*) as total")
+      .having("count(*) > 0")
+      .map {|c| [c.blood_type, c.total] }.to_h
       .each do |blood_type, total|
         message = "En Salvemos Otros SV contamos con #{total} donantes del tipo #{blood_type} no dejes de donar plasma #donatuplasma #covid19"
         params = {
           message: message,
           link: link
         }
-        FacebookPostingService.post_to_page params
+        begin
+          FacebookPostingService.post_to_page params
+        rescue => exception
+          puts "Failing posting for blood type #{blood_type}"
+        end
+        
       end
   end
 

--- a/lib/tasks/social_media.rake
+++ b/lib/tasks/social_media.rake
@@ -1,0 +1,19 @@
+namespace :social_media do
+  desc "TODO"
+  task daily_blood_donnors_report: :environment do
+    link = "https://salvemosotrosv.com/donantes"
+    Contact.group(:blood_type)\
+      .select("blood_type, count(*) as total")\
+      .having("count(*) > 0")\
+      .map {|c| [c.blood_type, c.total] }.to_h\
+      .each do |blood_type, total|
+        message = "En Salvemos Otros SV contamos con #{total} donantes del tipo #{blood_type} no dejes de donar plasma #donatuplasma #covid19"
+        params = {
+          message: message,
+          link: link
+        }
+        FacebookPostingService.post_to_page params
+      end
+  end
+
+end


### PR DESCRIPTION
## Changelog

**Descripcion:** Este feature consiste en una tarea que puede ser configurada como un cron jon diario que publique hacia las paginas de facebook y twitter los totales de donantes por tipo de sangre con el objetivo de generar contenido en redes y la ciudadania este mas pendiente de los donantes disponibles

**Cambios:**

- Se agrego rake task en `lib/task/social_media.rake`
- Se agrego [dotenv-rails gem](https://github.com/bkeepers/dotenv) para manejar variables de entorno en desarrollo
- Se agrego la ruta `get :donantes, to: 'contacts#index', defaults: { donors: 1 }` para tener una forma mas directa de acceder a los donantes
- Se agrego la clase `FacebookPostingService` que funciona como integracion con facebook

## TODO
- Agregar `TwitterPostingService` class para integrar publicaciones automaticas con Twitter
- Deployment apropiado en caso de que este PR sea aprovado
- Agregar un filtro por tipo de sangre al `ContactsController` para que muestre un tipo de sangre especifico y se pueda viralizar mas las publicaciones